### PR TITLE
在values中，增加starrocksOperator的imagePullPolicy配置

### DIFF
--- a/charts/kube-starrocks/templates/starrocks-operator/deployment.yaml
+++ b/charts/kube-starrocks/templates/starrocks-operator/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - --leader-elect
         image: "{{ .Values.starrocksOperator.image.repository }}:{{ .Values.starrocksOperator.image.tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.starrocksOperator.imagePullPolicy }}
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/kube-starrocks/values.yaml
+++ b/charts/kube-starrocks/values.yaml
@@ -19,6 +19,7 @@ starrocksOperator:
     # image sliced by "repository:tag"
     repository: starrocks/operator
     tag: latest
+  imagePullPolicy: Always
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
有部分在内网使用Helm部署StarRocks的用户，不能拉取镜像，采用直接上传镜像到k8s宿主机的方式。在value中增加镜像拉取的参数设置，在必要时，改变这一选项为IfNotPresent，
从而能够利用本地镜像