### PR TITLE
增加logStorageSize配置,当增加此配置时,fe和be的log存储使用pvc管理

### DIFF
--- a/charts/kube-starrocks/templates/_helpers.tpl
+++ b/charts/kube-starrocks/templates/_helpers.tpl
@@ -89,10 +89,34 @@ be.conf: |-
 {{- end }}
 {{- end }}
 
+{{- define "starrockscluster.fe.meta.suffix" -}}
+{{- print "-meta" }}
+{{- end }}
+
 {{- define "starrockscluster.fe.meta.path" -}}
 {{- print "/opt/starrocks/fe/meta" }}
 {{- end }}
 
+{{- define "starrockscluster.fe.log.suffix" -}}
+{{- print "-log" }}
+{{- end }}
+
+{{- define "starrockscluster.fe.log.path" -}}
+{{- print "/opt/starrocks/fe/log" }}
+{{- end }}
+
+{{- define "starrockscluster.be.data.suffix" -}}
+{{- print "-data" }}
+{{- end }}
+
 {{- define "starrockscluster.be.data.path" -}}
 {{- print "/opt/starrocks/be/storage" }}
+{{- end }}
+
+{{- define "starrockscluster.be.log.suffix" -}}
+{{- print "-log" }}
+{{- end }}
+
+{{- define "starrockscluster.be.log.path" -}}
+{{- print "/opt/starrocks/be/log" }}
 {{- end }}

--- a/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
+++ b/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
@@ -65,7 +65,7 @@ spec:
       resolveKey: fe.conf
 {{- if .Values.starrocksFESpec.storageSpec.name }}
     storageVolumes:
-    - name: {{ .Values.starrocksFESpec.storageSpec.name }}
+    - name: {{ .Values.starrocksFESpec.storageSpec.name }}{{ template "starrockscluster.fe.meta.suffix" . }}
 {{- if .Values.starrocksFESpec.storageSpec.storageClassName }}
       storageClassName: {{ .Values.starrocksFESpec.storageSpec.storageClassName }}
 {{- end }}
@@ -73,6 +73,16 @@ spec:
       storageSize: {{ .Values.starrocksFESpec.storageSpec.storageSize }}
 {{- end }}
       mountPath: {{ template "starrockscluster.fe.meta.path" . }}
+{{- end }}
+{{- if .Values.starrocksFESpec.storageSpec.logStorageSize }}
+    - name: {{ .Values.starrocksFESpec.storageSpec.name }}{{ template "starrockscluster.fe.log.suffix" . }}
+{{- if .Values.starrocksFESpec.storageSpec.storageClassName }}
+      storageClassName: {{ .Values.starrocksFESpec.storageSpec.storageClassName }}
+{{- end }}
+{{- if .Values.starrocksFESpec.storageSpec.logStorageSize }}
+      storageSize: {{ .Values.starrocksFESpec.storageSpec.logStorageSize }}
+{{- end }}      
+      mountPath: {{ template "starrockscluster.fe.log.path" . }}
 {{- end }}
 
 {{- if .Values.starrocksBeSpec }}
@@ -130,7 +140,7 @@ spec:
       resolveKey: be.conf
 {{- if .Values.starrocksBeSpec.storageSpec.name }}
     storageVolumes:
-    - name: {{ .Values.starrocksBeSpec.storageSpec.name }}
+    - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.data.suffix" . }}
 {{- if .Values.starrocksBeSpec.storageSpec.storageClassName }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
 {{- end }}
@@ -138,6 +148,16 @@ spec:
       storageSize: {{ .Values.starrocksBeSpec.storageSpec.storageSize }}
 {{- end }}
       mountPath: {{template "starrockscluster.be.data.path" . }}
+{{- end }}
+{{- if .Values.starrocksBeSpec.storageSpec.logStorageSize }}
+    - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.log.suffix" . }}
+{{- if .Values.starrocksBeSpec.storageSpec.storageClassName }}
+      storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
+{{- end }}
+{{- if .Values.starrocksBeSpec.storageSpec.logStorageSize }}
+      storageSize: {{ .Values.starrocksBeSpec.storageSpec.logStorageSize }}
+{{- end }}
+      mountPath: {{template "starrockscluster.be.log.path" . }}
 {{- end }}
 {{- end }}
 

--- a/charts/kube-starrocks/values.yaml
+++ b/charts/kube-starrocks/values.yaml
@@ -19,7 +19,6 @@ starrocksOperator:
     # image sliced by "repository:tag"
     repository: starrocks/operator
     tag: latest
-  imagePullPolicy: Always
   resources:
     limits:
       cpu: 500m
@@ -49,7 +48,7 @@ starrocksFESpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/fe-ubuntu
-    tag: 2.5.5
+    tag: 2.5.4
 
   # add annotations for fe pods. example, if you want to config monitor for datadog, you can config the annotations. etc...
   annotations: {}
@@ -139,6 +138,8 @@ starrocksFESpec:
     storageClassName: ""
     #the persistent volume size default 1 Gi.
     storageSize: 1Gi
+    # Setting this parameter can persist log storage
+    logStorageSize: 1Gi
 
   # the config for start fe. the base information as follows.
   config: |
@@ -158,7 +159,7 @@ starrocksCnSpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/cn-ubuntu
-    tag: 2.5.5
+    tag: 2.5.4
   # serviceAccount for cn access cloud service.
   #serviceAccount: starrocks
 
@@ -285,7 +286,7 @@ starrocksBeSpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/be-ubuntu
-    tag: 2.5.5
+    tag: 2.5.4
   ## serviceAccount for be access cloud service.
   #serviceAccount: starrocks
 
@@ -377,6 +378,8 @@ starrocksBeSpec:
     # you must set name when you set storageClassName
     storageClassName: ""
     storageSize: 1Ti
+    # Setting this parameter can persist log storage
+    logStorageSize: 1Gi
 
   # the config for start be. the base information as follows.
   config: |


### PR DESCRIPTION
在fe和be的storageSpec增加logStorageSize，当配置此参数时，fe和be的log存储使用pvc管理，替代默认的emptyDir。增加此配置是为了在某些情况下，保存be的日志，以分析be崩溃的原因。